### PR TITLE
fixed NullPointerException

### DIFF
--- a/android/src/main/java/com/pollfish/RNPollfishModule.java
+++ b/android/src/main/java/com/pollfish/RNPollfishModule.java
@@ -104,7 +104,7 @@ public class RNPollfishModule extends ReactContextBaseJavaModule implements
             params.signature(signature);
         }
 
-        if (!rewardInfoMap.equals(null)) {
+        if (rewardInfoMap != null) {
             RewardInfo rewardInfo = new RewardInfo(
                     rewardInfoMap.getString("rewardName"),
                     rewardInfoMap.getDouble("rewardConversion"));


### PR DESCRIPTION
this commit fixes a NullPointerException when rewardInfoMap is null

`java.lang.NullPointerException: Attempt to invoke virtual method 'boolean java.lang.Object.equals(java.lang.Object)' on a null object reference`